### PR TITLE
don't set markdown to output to dir either

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,7 +11,6 @@ makedocs(
     # TODO expand (https://github.com/SciML/SciMLDocs/blob/0fa5c9c43cf768588124861e76c7854e671ad9d7/docs/make.jl#L29C1-L29C63)
     format = DocumenterVitepress.MarkdownVitepress(
         repo = "https://github.com/BioJulia/BioJuliaDocs",
-        md_output_path = ".",
     ),
     pages = [
         "Getting Started" => [


### PR DESCRIPTION
we need a normpath or something in DV's cleanup method...I think it's `clean_md_output` or so